### PR TITLE
Adding Docker container

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,6 +1,6 @@
-OPENAI_API_KEY="<token>"
-DEFAULT_MODEL_NAME="gpt-3.5-turbo"
-BOT_NAME="GPT"
+OPENAI_API_KEY=<token>
+DEFAULT_MODEL_NAME=gpt-3.5-turbo
+BOT_NAME=GPT
 BOT_ROLE="You are an internal chatbot assistant in a software development company called Flexiana."
-LOGLEVEL="DEBUG"
-PERMISSIONS_SET_CONTEXT="admin"
+LOGLEVEL=DEBUG
+PERMISSIONS_SET_CONTEXT=admin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM alpine:latest
+ 
+LABEL maintainer="František Polášek <iam@parallelo3301.org>"
+ 
+RUN apk add python3 py3-pip py3-wheel
+
+COPY ./requirements.txt /requirements.txt
+
+RUN pip install -r /requirements.txt && \
+    rm -rf /requirements.txt
+
+COPY ./bot.py /app/bot.py
+
+WORKDIR /app
+
+CMD ["python3", "bot.py"]
+

--- a/README.md
+++ b/README.md
@@ -143,4 +143,13 @@ pip install -r requirements.txt
 python3 bot.py
 ```
 
-4. You may also want to modify the system message in `bot.py` which says: `{"role": "system", "content": "You are an internal chatbot assistant in a software development company."}`
+4. You may also want to modify the bot role in `.env` which says: `"You are an internal chatbot assistant in a software development company."`
+
+
+## Running the bot in Docker container
+
+```
+docker build -t zulip-chatgpt-bot .
+docker-compose up -d 
+```
+

--- a/bot.py
+++ b/bot.py
@@ -16,7 +16,9 @@ load_dotenv()
 LOGLEVEL = os.environ.get('LOGLEVEL', 'INFO').upper()
 logging.basicConfig(level=LOGLEVEL)
 
-conn = sqlite3.connect('data.db')
+if not os.path.exists('data'):
+    os.makedir('data')
+conn = sqlite3.connect('data/data.db')
 cur = conn.cursor()
 
 # Set up GPT-3 API key

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,17 @@
+version: "3.3"
+
+services:
+  zulip-chatgpt-bot:
+    image: zulip-chatgpt-bot
+    container_name: zulip-chatgpt-bot
+    restart: unless-stopped
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - DEFAULT_MODEL_NAME=${DEFAULT_MODEL_NAME}
+      - BOT_NAME=${BOT_NAME}
+      - BOT_ROLE=${BOT_ROLE}
+      - LOGLEVEL=${LOGLEVEL}
+      - PERMISSIONS_SET_CONTEXT=${PERMISSIONS_SET_CONTEXT}
+    volumes:
+      - ./.zuliprc:/app/.zuliprc
+      - ./data:/app/data


### PR DESCRIPTION
This PR adds dockerized execution of bot.

Note there are no quotes anymore around strings in `.env`, unless the string contains spaces. I'm removing them to make `.env` values passed through docker-compose.yaml and avoid double-quoting. 